### PR TITLE
Fix fatal error that is thrown when the input string has an invalid encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,23 @@
 {
     "name": "aternos/licensee",
     "description": "A library to detect well-known licenses based on their title or content.",
-    "type": "library",
     "license": "MIT",
-    "bin": ["bin/licensee-update-data"],
+    "type": "library",
+    "authors": [
+        {
+            "name": "Kurt Thiemann",
+            "email": "kurt@aternos.org"
+        }
+    ],
+    "require": {
+        "php": ">=8.3",
+        "ext-dom": "*",
+        "ext-yaml": "*",
+        "league/html-to-markdown": "^5.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5"
+    },
     "autoload": {
         "psr-4": {
             "Aternos\\Licensee\\": "src/"
@@ -14,21 +28,9 @@
             "Tests\\": "tests/"
         }
     },
-    "authors": [
-        {
-            "name": "Kurt Thiemann",
-            "email": "kurt@aternos.org"
-        }
+    "bin": [
+        "bin/licensee-update-data"
     ],
-    "require": {
-        "ext-dom": "*",
-        "league/html-to-markdown": "^5.1",
-        "ext-yaml": "*",
-        "php": ">=8.3"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^11.5"
-    },
     "scripts": {
         "test": "phpunit --config phpunit.xml --testdox"
     }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=8.3",
         "ext-dom": "*",
+        "ext-mbstring": "*",
         "ext-yaml": "*",
         "league/html-to-markdown": "^5.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fe4f89bdfb7f1cef5384d076649a52d",
+    "content-hash": "6e23ea641b49d73be7cd5758dd0cb962",
     "packages": [
         {
             "name": "league/html-to-markdown",
@@ -1791,6 +1791,7 @@
     "platform": {
         "php": ">=8.3",
         "ext-dom": "*",
+        "ext-mbstring": "*",
         "ext-yaml": "*"
     },
     "platform-dev": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a50f7a4b29584a6a1cba2f3aa2458f53",
+    "content-hash": "5fe4f89bdfb7f1cef5384d076649a52d",
     "packages": [
         {
             "name": "league/html-to-markdown",
@@ -1789,6 +1789,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "php": ">=8.3",
         "ext-dom": "*",
         "ext-yaml": "*"
     },

--- a/src/License/Text/LicenseText.php
+++ b/src/License/Text/LicenseText.php
@@ -33,9 +33,13 @@ use Aternos\Licensee\TextTransformer\StripUnlicenseOptionalTransformer;
 use Aternos\Licensee\TextTransformer\StripUrlTransformer;
 use Aternos\Licensee\TextTransformer\StripVersionTransformer;
 use Aternos\Licensee\TextTransformer\StripWhitespaceTransformer;
+use Aternos\Licensee\TextTransformer\TextTransformer;
 
 class LicenseText
 {
+    /**
+     * @var TextTransformer[]
+     */
     protected array $transformers;
     protected ?string $normalizedContent = null;
     protected ?array $wordSet = null;
@@ -101,7 +105,7 @@ class LicenseText
     public function getNormalizedContent(): string
     {
         if ($this->normalizedContent === null) {
-            $this->normalizedContent = $this->content;
+            $this->normalizedContent = mb_convert_encoding($this->content, 'utf8');
             foreach ($this->transformers as $transformer) {
                 $this->normalizedContent = $transformer->transform($this->normalizedContent);
                 $this->normalizedContent = RegExpException::handleNull(preg_replace("# +#", " ", $this->normalizedContent));


### PR DESCRIPTION
When the input license text has an invalid encoding a fatal error is thrown by the html to markdown converter:
```
PHP Fatal error:  Uncaught TypeError: preg_replace(): Argument #3 ($subject) must be of type array|string, null given in /web/vendor/league/html-to-markdown/src/Converter/TextConverter.php:24
Stack trace:
#0 /web/vendor/league/html-to-markdown/src/Converter/TextConverter.php(24): preg_replace()
#1 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(222): League\HTMLToMarkdown\Converter\TextConverter->convert()
#2 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(193): League\HTMLToMarkdown\HtmlConverter->convertToMarkdown()
#3 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(188): League\HTMLToMarkdown\HtmlConverter->convertChildren()
#4 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(188): League\HTMLToMarkdown\HtmlConverter->convertChildren()
#5 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(188): League\HTMLToMarkdown\HtmlConverter->convertChildren()
#6 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(188): League\HTMLToMarkdown\HtmlConverter->convertChildren()
#7 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(188): League\HTMLToMarkdown\HtmlConverter->convertChildren()
#8 /web/vendor/league/html-to-markdown/src/HtmlConverter.php(99): League\HTMLToMarkdown\HtmlConverter->convertChildren()
#9 /web/vendor/aternos/licensee/src/TextTransformer/HtmlTransformer.php(26): League\HTMLToMarkdown\HtmlConverter->convert()
#10 /web/vendor/aternos/licensee/src/License/Text/LicenseText.php(106): Aternos\Licensee\TextTransformer\HtmlTransformer->transform()
#11 /web/vendor/aternos/licensee/src/License/Text/LicenseText.php(131): Aternos\Licensee\License\Text\LicenseText->getNormalizedContent()
#12 /web/vendor/aternos/licensee/src/Matcher/ExactMatcher.php(15): Aternos\Licensee\License\Text\LicenseText->getWordSet()
#13 /web/vendor/aternos/licensee/src/Matcher/Matcher.php(45): Aternos\Licensee\Matcher\ExactMatcher->match()
#14 /web/vendor/aternos/licensee/src/Matcher/Matcher.php(62): Aternos\Licensee\Matcher\Matcher->getAllMatches()
#15 /web/vendor/aternos/licensee/src/Licensee.php(80): Aternos\Licensee\Matcher\Matcher->getMatch()
#16 /web/src/Processor/MetaDataExtractor/MetaFile/LicenseFile.php(34): Aternos\Licensee\Licensee->findLicenseByContent()
```

This PR fixes that by converting the text to UTF-8 using `mb_convert_encoding` before applying the transformers. The mbstring extension has been added as a required dependency.